### PR TITLE
 cleaning of rf annotations in the final RF filtering files:

### DIFF
--- a/variant_qc/prepare_data_release.py
+++ b/variant_qc/prepare_data_release.py
@@ -112,7 +112,7 @@ def make_info_expr(ht: hl.Table) -> Dict[str, hl.expr.Expression]:
         'rf_negative_label': ht.fail_hard_filters,
         'rf_label': ht.rf_label,
         'rf_train': ht.rf_train,
-        'rf_tp_probability': ht.rf_probability.get('TP'),
+        'rf_tp_probability': ht.rf_probability,
         'transmitted_singleton': ht.transmitted_singleton,
         'variant_type': ht.variant_type,
         'allele_type': ht.allele_type,

--- a/variant_qc/variantqc.py
+++ b/variant_qc/variantqc.py
@@ -541,6 +541,7 @@ def prepare_final_ht(data_type: str, run_hash: str, snp_bin_cutoff: int, indel_b
     annotations_expr = {
         'tp': hl.or_else(ht.tp, False),
         'transmitted_singleton': hl.or_missing(freq_ht[ht.key].freq[1].AC[1] == 1, ht.transmitted_singleton)
+        'rf_probability': ht.rf_probability["TP"]
     }
     if 'feature_imputed' in ht.row:
         annotations_expr.update(
@@ -550,6 +551,9 @@ def prepare_final_ht(data_type: str, run_hash: str, snp_bin_cutoff: int, indel_b
     ht = ht.transmute(
         **annotations_expr
     )
+
+    #This column is added by the RF module based on a 0.5 threshold which doesn't correspond to what we use
+    ht = ht.drop(ht.rf_prediction)
 
     return ht
 


### PR DESCRIPTION
 1. Drop `rf_prediction` as it is generated based on 0.5 threshold
 2. Make `rf_probablity` a float (using the "TP" class) rather than a Dict.