### PR TITLE
Lint all files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
           pip install -r requirements.txt
           pip install pylint
       - name: Run Pylint
-        run: pylint --disable=W --disable=C --disable=R gnomad_qc
+        run: ./lint --disable=W

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,6 @@
+[MESSAGES CONTROL]
+
+disable=
+  unused-wildcard-import,
+  R,
+  C

--- a/lint
+++ b/lint
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+# Since this repository is structured as a collection of stand-alone scripts
+# rather than a package, Pylint must be run with the list of individual Python
+# modules.
+
+find . -type f -name '*.py' | xargs pylint "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/macarthur-lab/gnomad_hail.git@master
+gnomad==0.1.0
 scikit-learn
 scipy<1.4
 hail


### PR DESCRIPTION
Most directories are not set up as packages, so `pylint gnomad_qc` was not checking all files.